### PR TITLE
Description and hash file for CVE-2018-9206

### DIFF
--- a/Scanner/CVE-2018-9206/README.md
+++ b/Scanner/CVE-2018-9206/README.md
@@ -3,12 +3,12 @@
 ## cve_2018_9206_jquery_file_upload_hash.txt
 
 This file contains sha1 sums to help identify vulnerable server-side components of JQuery: File Upload Plugin _server/php/index.php_
-The first part of the file name is the git commit id.
+The last part of the file name is the git commit id.
 
 
 ## Covered CVE
 
-The list covers files vulnerable to CVE-2018-9206 (arbitrary file upload and execution vulnerabiliry in JQuery File Upload Plugin versions < 9.22.1)
+The list covers files vulnerable to CVE-2018-9206 (arbitrary file upload and execution vulnerability in JQuery File Upload Plugin versions < 9.22.1)
 
 Vulnerability: Unauthenticated arbitrary file upload
 * CVE: -

--- a/Scanner/CVE-2018-9206/README.md
+++ b/Scanner/CVE-2018-9206/README.md
@@ -1,0 +1,20 @@
+# JQuery File Upload Plugin -- Hash File
+
+## cve_2018_9206_jquery_file_upload_hash.txt
+
+This file contains sha1 sums to help identify vulnerable server-side components of JQuery: File Upload Plugin _server/php/index.php_
+The first part of the file name is the git commit id.
+
+
+## Covered CVE
+
+The list covers files vulnerable to CVE-2018-9206 (arbitrary file upload and execution vulnerabiliry in JQuery File Upload Plugin versions < 9.22.1)
+
+Vulnerability: Unauthenticated arbitrary file upload
+* CVE: -
+* Affected versions: <= v9.22.0
+* Links:
+ * https://nvd.nist.gov/vuln/detail/CVE-2018-9206
+ * https://github.com/blueimp/jQuery-File-Upload
+ * https://github.com/lcashdol/Exploits/tree/master/CVE-2018-9206
+

--- a/Scanner/CVE-2018-9206/README.md
+++ b/Scanner/CVE-2018-9206/README.md
@@ -14,7 +14,7 @@ Vulnerability: Unauthenticated arbitrary file upload
 * CVE: -
 * Affected versions: <= v9.22.0
 * Links:
- * https://nvd.nist.gov/vuln/detail/CVE-2018-9206
- * https://github.com/blueimp/jQuery-File-Upload
- * https://github.com/lcashdol/Exploits/tree/master/CVE-2018-9206
+   * https://nvd.nist.gov/vuln/detail/CVE-2018-9206
+   * https://github.com/blueimp/jQuery-File-Upload
+   * https://github.com/lcashdol/Exploits/tree/master/CVE-2018-9206
 

--- a/Scanner/CVE-2018-9206/cve_2018_9206_jquery_file_upload_hash.txt
+++ b/Scanner/CVE-2018-9206/cve_2018_9206_jquery_file_upload_hash.txt
@@ -1,0 +1,7 @@
+9c62eed0ac838664e7f9a940475d3a8966d13ab7; JQuery File Upload, vulnerable to CVE-2018-9206, version server-php-index.php-04c6bda6b97eb989f5c7523913b0adc4e206d74e
+4e7c609f220c0027b810e6a937b6ecf28e7a889a; JQuery File Upload, vulnerable to CVE-2018-9206, version server-php-index.php-4f2bd3e1f395db5342399869a1e12d1b265a2c32
+8730d445c674bce95b6e2468cb0fe9afe712fa16; JQuery File Upload, vulnerable to CVE-2018-9206, version server-php-index.php-66b7e40b4ca08e5afbb6a2533cb1e371db8ebe3c
+b41b4e7f14a3c38d6f2d5bbe672bec1cc6ce93f3; JQuery File Upload, vulnerable to CVE-2018-9206, version server-php-index.php-869535dffaf4249b7b04aa2ba41fb08f17ea77c9
+56ed95edce6ea51499c8342d7ca2c374d761734a; JQuery File Upload, vulnerable to CVE-2018-9206, version server-php-index.php-94d6df8041ce97e888f70d26090b1b4d1a6d9a5b
+d132ae29cf1ada38049c94f154e2ae2d0e56085a; JQuery File Upload, vulnerable to CVE-2018-9206, version server-php-index.php-eb985ea473e021ffe714096e0f03f5a3f56048d4
+

--- a/Scanner/CVE-2018-9206/cve_2018_9206_jquery_file_upload_hash.txt
+++ b/Scanner/CVE-2018-9206/cve_2018_9206_jquery_file_upload_hash.txt
@@ -4,4 +4,3 @@
 b41b4e7f14a3c38d6f2d5bbe672bec1cc6ce93f3; JQuery File Upload, vulnerable to CVE-2018-9206, version server-php-index.php-869535dffaf4249b7b04aa2ba41fb08f17ea77c9
 56ed95edce6ea51499c8342d7ca2c374d761734a; JQuery File Upload, vulnerable to CVE-2018-9206, version server-php-index.php-94d6df8041ce97e888f70d26090b1b4d1a6d9a5b
 d132ae29cf1ada38049c94f154e2ae2d0e56085a; JQuery File Upload, vulnerable to CVE-2018-9206, version server-php-index.php-eb985ea473e021ffe714096e0f03f5a3f56048d4
-


### PR DESCRIPTION
# JQuery File Upload Plugin -- Hash File

## cve_2018_9206_jquery_file_upload_hash.txt

This file contains sha1 sums to help identify vulnerable server-side components of JQuery: File Upload Plugin _server/php/index.php_
The first part of the file name is the git commit id.


## Covered CVE

The list covers files vulnerable to CVE-2018-9206 (arbitrary file upload and execution vulnerabiliry in JQuery File Upload Plugin versions < 9.22.1)

Vulnerability: Unauthenticated arbitrary file upload
* CVE: -
* Affected versions: <= v9.22.0
* Links:
 * https://nvd.nist.gov/vuln/detail/CVE-2018-9206
 * https://github.com/blueimp/jQuery-File-Upload
 * https://github.com/lcashdol/Exploits/tree/master/CVE-2018-9206
